### PR TITLE
Making the tracker check the new sni port while falling back to the old one.

### DIFF
--- a/packages/tracker-core/SnesSession.ts
+++ b/packages/tracker-core/SnesSession.ts
@@ -21,7 +21,8 @@ type WsConnection = ws.connection;
 
 const queue = new Queue(1);
 
-const wsServer = "ws://localhost:8080";
+const wsServer = "ws://localhost:23074";
+const wsServerLegacyPort = "ws://localhost:8080";
 
 export class SnesSession {
   public info: SnesInfo | null;
@@ -51,7 +52,7 @@ export class SnesSession {
     this._devicePromise = null;
     this._deviceInfoPromise = null;
     this._attachPromise = null;
-    this._externalLogger = () => {};
+    this._externalLogger = () => { };
     this.error = null;
   }
 
@@ -91,8 +92,13 @@ export class SnesSession {
   public async connect() {
     this.resetState();
 
+    // SNI changed the port it listens on. Check current and legacy ports
     if (!this._client) {
       this._client = new ws.w3cwebsocket(wsServer);
+    }
+
+    if (!this._client) {
+      this._client = new ws.w3cwebsocket(wsServerLegacyPort);
     }
 
     this._isConnected = false;


### PR DESCRIPTION
With the more recent versions of SNI using the port 8080 has been deprecated.  The FF6WC community has been working around this using environment variables to make SNI still listen on port 8080.  This change will make the tracker try to connect on the new port first and then fall back to the old port for players still using older versions of SNI.